### PR TITLE
Add experimental support for crypted password

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ CFLAGS+=-W -Wall -Wextra \
         -Wunused -Winit-self -Wpointer-arith -Wredundant-decls \
         -Wmissing-prototypes -Wmissing-format-attribute -Wmissing-noreturn \
         -std=gnu99 -pipe -DSYSRQD_VERSION="\"$(VERSION)\"" -O3
+LDFLAGS+=-lcrypt
 
 SBINDIR=$(DESTDIR)/usr/sbin
 #MANDIR=$(DESTDIR)/usr/share/man/man1
@@ -13,7 +14,7 @@ INSTALL = install
 #MAN=sysrqd.1
 
 $(BIN): $(O)
-	$(CC) $(LDFLAGS) -o $(BIN) $(O)
+	$(CC) -o $(BIN) $(O) $(LDFLAGS) 
 
 install: $(BIN)
 	$(INSTALL) -d -m 755 $(SBINDIR)


### PR DESCRIPTION
Hi, I've written a quick patch which implements support for crypted passwords. This makes it possible to put a password hash in /etc/sysrqd.secret with a command like "mkpasswd -m sha-512 > /etc/sysrqd.secret". The code attempts to detect a crypted password, so that cleartext passwords still work.

The motivation for this patch comes from diskless workstations and thin clients, which basically have world-readable NFS root filesystems so that the sysrqd password could be read by anybody. For this case something like bcrypt would be better, but I chose to use glibc's crypt for simplicity and to avoid additional dependencies.
